### PR TITLE
Edge services integration

### DIFF
--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -137,7 +137,10 @@ module.exports.run = function(opts, cb) {
       }
     }
   }
-  descriptor.main.required = true;
+  if (opts.runtime != EdgeServicesRuntimeOption) {
+    descriptor.main.required = true;
+  }
+  
   descriptor.api.required = true;
   options.validateSync(opts, descriptor);
   if (opts.debug) {
@@ -158,7 +161,7 @@ module.exports.run = function(opts, cb) {
       opts['env-var'] = opts['env-var'] === undefined ? [] : opts['env-var'];
       opts['config-var'] = opts['config-var'] === undefined ? [] : opts['config-var'];
       opts['vars'] = parseEnvConfigVars(opts['env-var'], opts['config-var'])
-    
+
       deploySeries = [
           function(done) {
             if (!opts.token) { // need to get a token with the username & password
@@ -406,18 +409,20 @@ function getDeploymentInfo(opts, request, done) {
     return;
   }
 
-  if (!fs.existsSync(path.join(opts.directory, opts.main))) {
-    // Main script might be an absolute path, so fix it up
-    opts.main = path.relative(opts.directory, opts.main);
-  }
-  if (!fs.existsSync(path.join(opts.directory, opts.main))) {
-    done(new Error(util.format('Main script file %s does not seem to exist', opts.main)));
-    return;
-  }
-  if (path.dirname(opts.main) !== '.') {
-    done(new Error(util.format('Main script file %s must be in the top level directory',
-      opts.main)));
+  if (opts.runtime != EdgeServicesRuntimeOption) {
+    if (!fs.existsSync(path.join(opts.directory, opts.main))) {
+      // Main script might be an absolute path, so fix it up
+      opts.main = path.relative(opts.directory, opts.main);
+    }
+    if (!fs.existsSync(path.join(opts.directory, opts.main))) {
+      done(new Error(util.format('Main script file %s does not seem to exist', opts.main)));
       return;
+    }
+    if (path.dirname(opts.main) !== '.') {
+      done(new Error(util.format('Main script file %s must be in the top level directory',
+        opts.main)));
+        return;
+    }
   }
 
   // Check out some specific parameters that aren't caught by the generic stuff

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -7,6 +7,7 @@ var async = require('async');
 var fs = require('fs');
 var mustache = require('mustache');
 var _ = require('underscore');
+var post = require('request').post;
 var unzip = require('node-unzip-2');
 var targz = require('tar.gz')({}, {
   fromBase: true
@@ -20,6 +21,7 @@ var ziputils = require('../ziputils');
 var parseDeployments = require('./parsedeployments');
 var fetchproxy = require('./fetchproxy');
 var deployproxy = require('./deployproxy');
+var templates = require('./edgeServicesTemplates');
 
 var DeploymentDelay = 60;
 var ProxyBase = 'apiproxy';
@@ -150,7 +152,7 @@ module.exports.run = function(opts, cb) {
     if (opts.runtime === EdgeServicesRuntimeOption) {
       // set defaults
       opts['node-version'] = opts['node-version'] === undefined ? DefaultNodeVersion : opts['node-version'];
-      opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'localhost:3000' : opts.edgeserviceshost; // this will go away when we have a stable target
+      opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'https://apigee-interlude-gcpprod.e2e.apigee.net/turbo' : opts.edgeserviceshost;
       opts.verbose = opts.verbose === undefined ? false : opts.verbose;
 
       opts['env-var'] = opts['env-var'] === undefined ? [] : opts['env-var'];
@@ -159,19 +161,30 @@ module.exports.run = function(opts, cb) {
     
       deploySeries = [
           function(done) {
+            if (!opts.token) { // need to get a token with the username & password
+              getToken(opts, function(err, token) {
+                if (err) {
+                  return done(err);
+                }
+                
+                opts.token = token;
+                request = defaults.defaultRequest(opts)
+                
+                done();
+              })
+            } else {
+              done();
+            }
+          },
+          function(done) {
             importDeployToEdgeServices(opts, request, done);
           },
           function(done) {
-            createApiProxy(opts, request, done);
-          },
-          function(done) {
-            createTarget(opts, request, done);
-          },
-          function(done) {
-            createProxy(opts, request, done);
-          },
-          function(done) {
-            deployProxy(opts, request, done);
+            if (!opts['preserve-policies']) {
+              uploadEdgeServicesBundle(opts, request, done);
+            } else {
+              done();
+            }
           }
         ]
     } else if (opts.runtime === undefined || opts.runtime === TriremeRuntimeOption) { // default to Trireme 
@@ -490,6 +503,29 @@ function proxyCreationDone(err, req, body, opts, done) {
   }
 }
 
+function getToken(opts, cb) {
+  var ssoURL = opts.baseuri && opts.baseuri.indexOf('e2e') > -1 ? 'https://login.e2e.apigee.net/oauth/token' : 'https://login.apigee.com/oauth/token'
+  post(ssoURL, {
+    form: {
+      username: opts.username,
+      password: opts.password.getValue(),
+      'grant_type': 'password'
+    },
+    headers: {
+      'Authorization': 'Basic ZWRnZWNsaTplZGdlY2xpc2VjcmV0',
+      'Accept': 'application/json;charset=utf-8',
+      'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8'
+    },
+    json: true
+  }, function(err, res, body) {
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      return cb(new Error('received bad status code: ' + res.statusCode))
+    }
+
+    return cb(err, body['access_token'])
+  });
+}
+
 function importDeployToEdgeServices(opts, request, done) {
   async.waterfall([
     function(cb) {
@@ -502,6 +538,7 @@ function importDeployToEdgeServices(opts, request, done) {
 }
 
 function uploadNodeSourceToEdgeServices(opts, request, done) {
+  console.log('Importing application...this can take some time.')
   // get a temp file to archive the source code to
   tmp.file({postfix: '.tgz'}, function(err, target) {
     if (err) { return done(err) }
@@ -511,7 +548,7 @@ function uploadNodeSourceToEdgeServices(opts, request, done) {
     targz.compress(opts.directory, target, function(err) {
       if (err) { return done(err) }
 
-      var uri = util.format('http://%s/organizations/%s/apps?stream=%s', opts.edgeserviceshost, opts.organization, opts.verbose);
+      var uri = util.format('%s/organizations/%s/apps?stream=%s', opts.edgeserviceshost, opts.organization, opts.verbose);
       
       if (opts.debug) { console.log('importing the archived source code into EdgeServices'); }
       // import source code archive into EdgeServices, stream messages
@@ -540,7 +577,7 @@ function uploadNodeSourceToEdgeServices(opts, request, done) {
             return done(new Error(util.format('Error during application import: %s', msg.error)), msg)
           }
 
-          if (msg.done) {
+          if (msg.revision) {
             if (opts.debug || opts.verbose) { console.log(util.format('Application "%s" revision "%s" built for "%s"', opts.api, msg.revision.revision, opts.organization)) }
             return done(null, msg) // end with the last message passed to the results
           } else if (opts.verbose || opts.debug) {
@@ -553,34 +590,39 @@ function uploadNodeSourceToEdgeServices(opts, request, done) {
 }
 
 function deployEdgeServicesApplication(opts, request, imported, cb) {
-  var uri = util.format('http://%s/environments/%s:%s/deployments', opts.edgeserviceshost, opts.organization, opts.environments);
-  var payload = {
-    application: opts.api,
-    revision: imported.revision.revision,
-    envVars: opts['vars'] // combination of standard environment & configuration-referenced variables
-  }
-
-  if (opts.debug) { console.log('deploying application with payload:', payload); }
-  request({
-    uri: uri,
-    method: 'POST',
-    body: payload
-  }, function(err, res, body) {
-    if (err) { return cb(err); }
-
-    if (res.statusCode === 400) {
-      return cb(new Error('bad request, there was a missing parameter'));
-    } else if (res.statusCode === 409) {
-      return cb(new Error('a deployment with these parametes already exists. cancelling'));
-    } else if (res.statusCode === 201) {
-      return cb(undefined, {
-        import: imported,
-        deploy: JSON.parse(body)
-      });
-    } else {
-      return cb(new Error(util.format('encountered a non-OK status code: %d', res.statusCode)));
+  console.log('Deploying application...')
+  var environments = opts.environments.split(',');
+  environments.forEach(function(env, ndx, arr) {
+    var uri = util.format('%s/environments/%s:%s/deployments', opts.edgeserviceshost, opts.organization, env);
+    var payload = {
+      application: opts.api,
+      revision: imported.revision.revision,
+      envVars: opts['vars'] // combination of standard environment & configuration-referenced variables
     }
-  });
+
+    if (opts.debug) { console.log('deploying application with payload:', payload); }
+    request({
+      uri: uri,
+      method: 'POST',
+      body: payload
+    }, function(err, res, body) {
+      if (err) { return cb(err); }
+
+      if (res.statusCode === 400) {
+        return cb(new Error('bad request, there was a missing parameter'));
+      } else if (res.statusCode === 409) {
+        console.log('A deployment with these parameters already exists. Continuing...')
+        return cb();
+      } else if (res.statusCode === 200) {
+        return cb(undefined, {
+          import: imported,
+          deploy: body
+        });
+      } else {
+        return cb(new Error(util.format('encountered a non-OK status code: %d', res.statusCode)));
+      }
+    });
+  })
 }
 
 function parseEnvConfigVars(envVarStrings, configVarStrings) {
@@ -618,6 +660,49 @@ function parseEnvConfigVars(envVarStrings, configVarStrings) {
   });
 
   return parsed
+}
+
+function uploadEdgeServicesBundle(opts, request, done) {
+  tmp.dir({unsafeCleanup: true}, function(err, tmpDirPath, cleanup) {
+    var proxyBundleBase = path.join(tmpDirPath, 'apiproxy');
+    fs.mkdirSync(proxyBundleBase);
+    
+    // write base proxy file
+    var rootDoc = mustache.render(templates.rootXmlTemplate, opts);
+    var rootEntryName = opts.api + '.xml';
+    fs.writeFileSync(path.join(proxyBundleBase, rootEntryName), rootDoc);
+
+    // write target file
+    var targetsDirPath = path.join(proxyBundleBase, 'targets');
+    fs.mkdirSync(targetsDirPath);
+    var targetDoc = mustache.render(templates.defaultTargetTemplate, opts);
+    fs.writeFileSync(path.join(targetsDirPath, 'default.xml'), targetDoc);
+
+    // write resource file
+    var resourceDirPath = path.join(proxyBundleBase, 'resources');
+    fs.mkdirSync(resourceDirPath);
+    var jscDirPath = path.join(resourceDirPath, 'jsc')
+    fs.mkdirSync(jscDirPath);
+    fs.writeFileSync(path.join(jscDirPath, 'gen-turbo-req.js'), templates.genTurboReqjs)
+
+    // write proxies file
+    var proxiesDirPath = path.join(proxyBundleBase, 'proxies');
+    fs.mkdirSync(proxiesDirPath);
+    var proxyDoc = mustache.render(templates.defaultProxyTemplate, opts);
+    fs.writeFileSync(path.join(proxiesDirPath, 'default.xml'), proxyDoc);
+
+    // write policy files
+    var policiesDirPath = path.join(proxyBundleBase, 'policies');
+    fs.mkdirSync(policiesDirPath);
+    fs.writeFileSync(path.join(policiesDirPath, 'GetTurboConfig.xml'), templates.getTurboConfig)
+    fs.writeFileSync(path.join(policiesDirPath, 'GenerateTurboRequest.xml'), templates.genTurboReqPolicy)
+
+    opts.directory = tmpDirPath
+    deployproxy.run(opts, function(err, dep) {
+      cleanup();
+      done(err, dep)
+    });
+  });
 }
 
 function uploadNodeSource(opts, request, done) {
@@ -693,26 +778,14 @@ function createTarget(opts, request, done) {
   var targetDoc;
   
   // we need the XML for a HostedTarget (or whatever)...this is just a place holder that isn't a ScriptTarget
-  if (opts.runtime === EdgeServicesRuntimeOption) {
-    targetDoc = mustache.render(
-    '<TargetEndpoint name="default">' +
-    '<PreFlow name="PreFlow"/>' +
-    '<PostFlow name="PostFlow"/>' +
-    '<HTTPTargetConnection>' +
-    ' <Properties/>' +
-    ' <URL>https://edgeservices.apigee.net{{basepath}}</URL>' +
-    '</HTTPTargetConnection>' +
-    '</TargetEndpoint>', opts);
-  } else {
-    targetDoc = mustache.render(
-    '<TargetEndpoint name="default">' +
-    '<PreFlow name="PreFlow"/>' +
-    '<PostFlow name="PostFlow"/>' +
-    '<ScriptTarget>' +
-    '<ResourceURL>node://{{main}}</ResourceURL>' +
-    '</ScriptTarget>' +
-    '</TargetEndpoint>', opts);
-  }
+  targetDoc = mustache.render(
+  '<TargetEndpoint name="default">' +
+  '<PreFlow name="PreFlow"/>' +
+  '<PostFlow name="PostFlow"/>' +
+  '<ScriptTarget>' +
+  '<ResourceURL>node://{{main}}</ResourceURL>' +
+  '</ScriptTarget>' +
+  '</TargetEndpoint>', opts);
 
   var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=default',
               opts.baseuri, opts.organization, opts.api,

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -227,25 +227,33 @@ module.exports.run = function(opts, cb) {
         if (err) { return cb(err); }
         if (opts.debug) { console.log('results: %j', results); }
 
-        async.map(_.values(results[results.length - 1]),
-          function(result, cb) {
+        if (opts.runtime === EdgeServicesRuntimeOption) {
+          console.log(util.format('Deployment results:\n  Org: %s\n  Environments: %s\n  Application: %s\n  App Revision: %s\n', 
+            opts.organization, 
+            opts.environments, 
+            opts.api, 
+            results[1].import.revision));
+        } else {
+          async.map(_.values(results[results.length - 1]),
+            function(result, cb) {
 
-            if (opts.debug) { console.log('result: %j', result); }
+              if (opts.debug) { console.log('result: %j', result); }
 
-            var deployment = parseDeployments.parseDeploymentResult(result);
-            if (deployment) {
-              // Look up the deployed URI for user-friendliness
-              parseDeployments.getPathInfo([ deployment ], opts, function(err) {
-                // Ignore this error because deployment worked
-                if (err && opts.verbose) { console.log('Error looking up deployed path: %s', err); }
-                cb(undefined, deployment);
-              });
-            } else {
-              // Probably import-only -- do nothing
-              cb(undefined, {});
-            }
-          },
-          cb);
+              var deployment = parseDeployments.parseDeploymentResult(result);
+              if (deployment) {
+                // Look up the deployed URI for user-friendliness
+                parseDeployments.getPathInfo([ deployment ], opts, function(err) {
+                  // Ignore this error because deployment worked
+                  if (err && opts.verbose) { console.log('Error looking up deployed path: %s', err); }
+                  cb(undefined, deployment);
+                });
+              } else {
+                // Probably import-only -- do nothing
+                cb(undefined, {});
+              }
+            },
+            cb);
+        }
       });
   });
 };

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -99,6 +99,11 @@ var descriptor = defaults.defaultDescriptor({
     required: false,
     array: true
   },
+  'config-var': {
+    name: 'Configuration-referenced variables for EdgeServices',
+    required: false,
+    array: true
+  },
   edgeserviceshost: { // for testing while we don't have proxy
     name: 'hostname of EdgeServices to target',
     required: false
@@ -150,8 +155,11 @@ module.exports.run = function(opts, cb) {
       // set defaults
       opts.stream = opts.stream === undefined ? false : opts.stream;
       opts['node-version'] = opts['node-version'] === undefined ? DefaultNodeVersion : opts['node-version'];
-      opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'localhost:3000' : opts.edgeserviceshost;
-      opts['env-var'] = opts['env-var'] === undefined ? [] : parseEnvVars(opts['env-var']);
+      opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'localhost:3000' : opts.edgeserviceshost; // this will go away when we have a stable target
+      
+      opts['env-var'] = opts['env-var'] === undefined ? [] : opts['env-var'];
+      opts['config-var'] = opts['config-var'] === undefined ? [] : opts['config-var'];
+      opts['vars'] = parseEnvConfigVars(opts['env-var'], opts['config-var'])
     
       deploySeries = [
           function(done) {
@@ -561,7 +569,7 @@ function deployEdgeServicesApplication(opts, request, imported, cb) {
       name: opts.api,
       application: opts.api,
       revision: imported.revision.revision,
-      envVars: opts['env-var']
+      envVars: opts['vars'] // combination of standard environment & configuration-referenced variables
     }
   }, function(err, res, body) {
     if (err) { return cb(err); }
@@ -581,36 +589,40 @@ function deployEdgeServicesApplication(opts, request, imported, cb) {
   });
 }
 
-function parseEnvVars(envVarStrings) {
+function parseEnvConfigVars(envVarStrings, configVarStrings) {
   var parsed = []
   envVarStrings.forEach(function(envVar, ndx, arr) {
-    var split = envVar.split('=')
+    var pairSplit = envVar.split('=')
 
      // invalid param, skip it. TODO: do something better here
-    if (split.length < 2) { console.log(util.format('invalid environment variable pair, excluding: %s', envVar)); return }
-    
-    var key = split[0]
-    var val = split[1]
+    if (pairSplit.length < 2 || pairSplit[1] === '') { console.log(util.format('invalid environment variable pair, excluding: %s', envVar)); return }
 
-    var valSplit = val.split(':')
-    if (valSplit.length > 1) {
-      parsed.push({
-        name: key,
-        valueFrom: {
-          edgeConfigRef: {
-            name: valSplit[0],
-            key: valSplit[1]
-          }
-        }
-      })
-    } else {
-      parsed.push({
-        name: key,
-        value: val
-      })
-    }
+    parsed.push({
+      name: pairSplit[0],
+      value: pairSplit[1]
+    })
   });
 
+  configVarStrings.forEach(function(configVar, ndx, arr) {
+    var pairSplit = configVar.split('=')
+    
+    if (pairSplit.length < 2) { console.log(util.format('invalid configuration variable pair, excluding: %s', configVar)); return }
+
+    var refSplit = pairSplit[1].split(':')
+
+    if (refSplit.length < 2 || refSplit[1] === '') { console.log(util.format('invalid configuration variable reference, excluding: %s', configVar)); return }
+
+    parsed.push({
+      name: pairSplit[0],
+      valueFrom: {
+        edgeConfigRef: {
+          name: refSplit[0],
+          key: refSplit[1]
+        }
+      }
+    })
+  });
+console.log(util.inspect(parsed, false, null))
   return parsed
 }
 

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -611,8 +611,26 @@ function deployEdgeServicesApplication(opts, request, imported, cb) {
       if (res.statusCode === 400) {
         return cb(new Error('bad request, there was a missing parameter'));
       } else if (res.statusCode === 409) {
-        console.log('A deployment with these parameters already exists. Continuing...')
-        return cb();
+        console.log('A deployment with these parameters already exists...updating with this new revision')
+
+        request({
+          uri: util.format('%s/%s', uri, opts.api),
+          method: 'PATCH',
+          body: payload
+        }, function(err, res, body) {
+          if (err) { return cb(err); }
+
+          if (res.statusCode === 404) {
+            return cb(new Error('tried to update a deployment that did not exist, got a 404'))
+          } else if (res.statusCode !== 200) {
+            return cb(new Error('received an error during update: ' + res.statusCode))
+          } else {
+            return cb(undefined, {
+              import: imported,
+              deploy: body
+            })
+          }
+        });
       } else if (res.statusCode === 200) {
         return cb(undefined, {
           import: imported,
@@ -622,7 +640,7 @@ function deployEdgeServicesApplication(opts, request, imported, cb) {
         return cb(new Error(util.format('encountered a non-OK status code: %d', res.statusCode)));
       }
     });
-  })
+  });
 }
 
 function parseEnvConfigVars(envVarStrings, configVarStrings) {
@@ -663,50 +681,43 @@ function parseEnvConfigVars(envVarStrings, configVarStrings) {
 }
 
 function uploadEdgeServicesBundle(opts, request, done) {
-  var environments = opts.environments.split(',');
-  environments.forEach(function(env, ndx, arr) {
-    opts.environments = env
-    tmp.dir({unsafeCleanup: true}, function(err, tmpDirPath, cleanup) {
-      var proxyBundleBase = path.join(tmpDirPath, 'apiproxy');
-      fs.mkdirSync(proxyBundleBase);
-      
-      // write base proxy file
-      var rootDoc = mustache.render(templates.rootXmlTemplate, opts);
-      var rootEntryName = opts.api + '.xml';
-      fs.writeFileSync(path.join(proxyBundleBase, rootEntryName), rootDoc);
+  tmp.dir({unsafeCleanup: true}, function(err, tmpDirPath, cleanup) {
+    var proxyBundleBase = path.join(tmpDirPath, 'apiproxy');
+    fs.mkdirSync(proxyBundleBase);
+    
+    // write base proxy file
+    var rootDoc = mustache.render(templates.rootXmlTemplate, opts);
+    var rootEntryName = opts.api + '.xml';
+    fs.writeFileSync(path.join(proxyBundleBase, rootEntryName), rootDoc);
 
-      // write target file
-      var targetsDirPath = path.join(proxyBundleBase, 'targets');
-      fs.mkdirSync(targetsDirPath);
-      var targetDoc = mustache.render(templates.defaultTargetTemplate, opts);
-      fs.writeFileSync(path.join(targetsDirPath, 'default.xml'), targetDoc);
+    // write target file
+    var targetsDirPath = path.join(proxyBundleBase, 'targets');
+    fs.mkdirSync(targetsDirPath);
+    var targetDoc = mustache.render(templates.defaultTargetTemplate, opts);
+    fs.writeFileSync(path.join(targetsDirPath, 'default.xml'), targetDoc);
 
-      // write resource file
-      var resourceDirPath = path.join(proxyBundleBase, 'resources');
-      fs.mkdirSync(resourceDirPath);
-      var jscDirPath = path.join(resourceDirPath, 'jsc')
-      fs.mkdirSync(jscDirPath);
-      fs.writeFileSync(path.join(jscDirPath, 'gen-turbo-req.js'), templates.genTurboReqjs)
+    // write resource file
+    var resourceDirPath = path.join(proxyBundleBase, 'resources');
+    fs.mkdirSync(resourceDirPath);
+    var jscDirPath = path.join(resourceDirPath, 'jsc')
+    fs.mkdirSync(jscDirPath);
+    fs.writeFileSync(path.join(jscDirPath, 'gen-turbo-req.js'), templates.genTurboReqjs)
 
-      // write proxies file
-      var proxiesDirPath = path.join(proxyBundleBase, 'proxies');
-      fs.mkdirSync(proxiesDirPath);
-      var proxyDoc = mustache.render(templates.defaultProxyTemplate, opts);
-      fs.writeFileSync(path.join(proxiesDirPath, 'default.xml'), proxyDoc);
+    // write proxies file
+    var proxiesDirPath = path.join(proxyBundleBase, 'proxies');
+    fs.mkdirSync(proxiesDirPath);
+    var proxyDoc = mustache.render(templates.defaultProxyTemplate, opts);
+    fs.writeFileSync(path.join(proxiesDirPath, 'default.xml'), proxyDoc);
 
-      // write policy files
-      var policiesDirPath = path.join(proxyBundleBase, 'policies');
-      fs.mkdirSync(policiesDirPath);
-      fs.writeFileSync(path.join(policiesDirPath, 'GetTurboConfig.xml'), templates.getTurboConfig)
-      fs.writeFileSync(path.join(policiesDirPath, 'GenerateTurboRequest.xml'), templates.genTurboReqPolicy)
+    // write policy files
+    var policiesDirPath = path.join(proxyBundleBase, 'policies');
+    fs.mkdirSync(policiesDirPath);
+    fs.writeFileSync(path.join(policiesDirPath, 'GetTurboConfig.xml'), templates.getTurboConfig)
+    fs.writeFileSync(path.join(policiesDirPath, 'GenerateTurboRequest.xml'), templates.genTurboReqPolicy)
 
-      opts.directory = tmpDirPath
-      deployproxy.run(opts, function(err, dep) {
-        cleanup();
-        done(err, dep)
-      });
-    });
-  }); 
+    opts.directory = tmpDirPath
+    deployproxy.run(opts, done);
+  });
 }
 
 function uploadNodeSource(opts, request, done) {

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -8,6 +8,9 @@ var fs = require('fs');
 var mustache = require('mustache');
 var _ = require('underscore');
 var unzip = require('node-unzip-2');
+var targz = require('tar.gz')({}, {
+  fromBase: true
+})
 var tmp = require('tmp');
 tmp.setGracefulCleanup();
 
@@ -20,6 +23,9 @@ var deployproxy = require('./deployproxy');
 
 var DeploymentDelay = 60;
 var ProxyBase = 'apiproxy';
+var TriremeRuntimeOption = 'trireme';
+var EdgeServicesRuntimeOption = 'edgeServices'
+var DefaultNodeVersion = '7'
 
 // By default, do not run NPM remotely
 var DefaultResolveModules = false;
@@ -72,6 +78,30 @@ var descriptor = defaults.defaultDescriptor({
     name: 'Preserve policies from previous revision',
     shortOption: 'P',
     toggle: true
+  },
+  runtime: {
+    name: 'Runtime to deploy the Node.js app to',
+    shortOption: 'B',
+    required: false
+  },
+  stream: {
+    name: 'Stream EdgeServices API calls',
+    shortOption: 's',
+    toggle: true
+  },
+  'node-version': {
+    name: 'Version of node to use in EdgeServices',
+    shortOption: 'x',
+    required: false
+  },
+  'env-var': {
+    name: 'Environment variables for EdgeServices',
+    required: false,
+    array: true
+  },
+  edgeserviceshost: { // for testing while we don't have proxy
+    name: 'hostname of EdgeServices to target',
+    required: false
   }
 });
 module.exports.descriptor = descriptor;
@@ -112,17 +142,41 @@ module.exports.run = function(opts, cb) {
   }
 
   var request = defaults.defaultRequest(opts);
-
   getDeploymentInfo(opts, request, function(err) {
     if (err) { return cb(err); }
 
-    // if preserve-policies, we do something entirely different...
-    if (opts['preserve-policies'] && opts.deploymentVersion > 1) {
-      return preservePoliciesRun(opts, cb);
-    }
+    var deploySeries;
+    if (opts.runtime === EdgeServicesRuntimeOption) {
+      // set defaults
+      opts.stream = opts.stream === undefined ? false : opts.stream;
+      opts['node-version'] = opts['node-version'] === undefined ? DefaultNodeVersion : opts['node-version'];
+      opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'localhost:3000' : opts.edgeserviceshost;
+      opts['env-var'] = opts['env-var'] === undefined ? [] : parseEnvVars(opts['env-var']);
+    
+      deploySeries = [
+          function(done) {
+            importDeployToEdgeServices(opts, request, done);
+          },
+          function(done) {
+            createApiProxy(opts, request, done);
+          },
+          function(done) {
+            createTarget(opts, request, done);
+          },
+          function(done) {
+            createProxy(opts, request, done);
+          },
+          function(done) {
+            deployProxy(opts, request, done);
+          }
+        ]
+    } else if (opts.runtime === undefined || opts.runtime === TriremeRuntimeOption) { // default to Trireme 
+      // if preserve-policies, we do something entirely different...
+      if (opts['preserve-policies'] && opts.deploymentVersion > 1) {
+        return preservePoliciesRun(opts, cb);
+      }
 
-    // Run each function in series, and collect an array of results.
-    async.series([
+      deploySeries = [
         function(done) {
           createApiProxy(opts, request, done);
         },
@@ -141,7 +195,14 @@ module.exports.run = function(opts, cb) {
         function(done) {
           deployProxy(opts, request, done);
         }
-      ],
+      ]
+    } else {
+      return cb(new Error(util.format('invalid deploynodeapp runtime choice: %s', opts.runtime)))
+    }
+
+    // Run each function in series, and collect an array of results.
+    async.series(
+      deploySeries,
       function(err, results) {
         if (err) { return cb(err); }
         if (opts.debug) { console.log('results: %j', results); }
@@ -425,6 +486,134 @@ function proxyCreationDone(err, req, body, opts, done) {
   }
 }
 
+function importDeployToEdgeServices(opts, request, done) {
+  async.waterfall([
+    function(cb) {
+      uploadNodeSourceToEdgeServices(opts, request, cb);
+    },
+    function(imported, cb) {
+      deployEdgeServicesApplication(opts, request, imported, cb)
+    }
+  ], function(err, results) {
+    done(err, results)
+  })
+}
+
+function uploadNodeSourceToEdgeServices(opts, request, done) {
+  // get a temp file to archive the source code to
+  tmp.file({postfix: '.tgz'}, function(err, target) {
+    if (err) { return done(err) }
+
+    if (opts.debug) { console.log('compressing the source code'); }
+    // archive & compress the source code directory
+    targz.compress(opts.directory, target, function(err) {
+      if (err) { return done(err) }
+
+      var uri = util.format('http://%s/organizations/%s/apps?stream=%s', opts.edgeserviceshost, opts.organization, opts.stream);
+      
+      if (opts.debug) { console.log('importing the archived source code into EdgeServices'); }
+      // import source code archive into EdgeServices, stream messages
+      request({
+        uri: uri,
+        method: 'POST',
+        json: false,
+        formData: {
+          runtime: 'node',
+          runtimeVersion: opts['node-version'],
+          application: opts.api,
+          file: fs.createReadStream(target)
+        }
+      }).on('error', done)
+      .on('response', function(response) {
+        if (response.statusCode === 400) { // something was wrong in the request
+          return done(new Error('bad request, there was an issue with the request payload'))
+        } else if (response.statusCode !== 202) {
+          return done(new Error(util.format('Received non-OK status code: %d', response.statusCode)))
+        }
+
+        var lastMessage = {};
+        response.on('data', function(data) { // parse chunked transfer of response
+          var msg = JSON.parse(data)
+          if (msg.error !== undefined) {
+            return done(new Error(util.format('Error during application import: %s', msg.error)), msg)
+          }
+
+          if (msg.done) {
+            if (opts.debug || opts.verbose || opts.stream) { console.log(util.format('Application "%s" revision "%s" built for "%s"', opts.api, msg.revision.revision, opts.organization)) }
+            return done(null, msg) // end with the last message passed to the results
+          } else if (opts.verbose || opts.debug || opts.stream) {
+            console.log(msg.message)
+          }
+        })
+      })
+    })
+  })
+}
+
+function deployEdgeServicesApplication(opts, request, imported, cb) {
+  var uri = util.format('http://%s/environments/%s:%s/deployments', opts.edgeserviceshost, opts.organization, opts.environments);
+  
+  if (opts.debug) { console.log('deploying application'); }
+  request({
+    uri: uri,
+    method: 'POST',
+    body: {
+      name: opts.api,
+      application: opts.api,
+      revision: imported.revision.revision,
+      envVars: opts['env-var']
+    }
+  }, function(err, res, body) {
+    if (err) { return cb(err); }
+
+    if (res.statusCode === 400) {
+      return cb(new Error('bad request, there was a missing parameter'));
+    } else if (res.statusCode === 409) {
+      return cb(new Error('a deployment with these parametes already exists. cancelling'));
+    } else if (res.statusCode === 200) {
+      return cb(undefined, {
+        import: imported,
+        deploy: JSON.parse(body)
+      });
+    } else {
+      return cb(new Error(util.format('encountered a non-OK status code: %d', res.statusCode)));
+    }
+  });
+}
+
+function parseEnvVars(envVarStrings) {
+  var parsed = []
+  envVarStrings.forEach(function(envVar, ndx, arr) {
+    var split = envVar.split('=')
+
+     // invalid param, skip it. TODO: do something better here
+    if (split.length < 2) { console.log(util.format('invalid environment variable pair, excluding: %s', envVar)); return }
+    
+    var key = split[0]
+    var val = split[1]
+
+    var valSplit = val.split(':')
+    if (valSplit.length > 1) {
+      parsed.push({
+        name: key,
+        valueFrom: {
+          edgeConfigRef: {
+            name: valSplit[0],
+            key: valSplit[1]
+          }
+        }
+      })
+    } else {
+      parsed.push({
+        name: key,
+        value: val
+      })
+    }
+  });
+
+  return parsed
+}
+
 function uploadNodeSource(opts, request, done) {
 
   // Get a list of entries, broken down by which are directories,
@@ -495,7 +684,21 @@ function handleUploadResult(err, req, fileName, itemDone) {
 
 // Create a target endpoint that references the Node.js script
 function createTarget(opts, request, done) {
-  var targetDoc = mustache.render(
+  var targetDoc;
+  
+  // we need the XML for a HostedTarget (or whatever)...this is just a place holder that isn't a ScriptTarget
+  if (opts.runtime === EdgeServicesRuntimeOption) {
+    targetDoc = mustache.render(
+    '<TargetEndpoint name="default">' +
+    '<PreFlow name="PreFlow"/>' +
+    '<PostFlow name="PostFlow"/>' +
+    '<HTTPTargetConnection>' +
+    ' <Properties/>' +
+    ' <URL>https://edgeservices.apigee.net{{basepath}}</URL>' +
+    '</HTTPTargetConnection>' +
+    '</TargetEndpoint>', opts);
+  } else {
+    targetDoc = mustache.render(
     '<TargetEndpoint name="default">' +
     '<PreFlow name="PreFlow"/>' +
     '<PostFlow name="PostFlow"/>' +
@@ -503,6 +706,7 @@ function createTarget(opts, request, done) {
     '<ResourceURL>node://{{main}}</ResourceURL>' +
     '</ScriptTarget>' +
     '</TargetEndpoint>', opts);
+  }
 
   var uri = util.format('%s/v1/o/%s/apis/%s/revisions/%d/targets?name=default',
               opts.baseuri, opts.organization, opts.api,

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -157,6 +157,7 @@ module.exports.run = function(opts, cb) {
       opts['node-version'] = opts['node-version'] === undefined ? DefaultNodeVersion : opts['node-version'];
       opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'https://apigee-interlude-gcpprod.e2e.apigee.net/turbo' : opts.edgeserviceshost;
       opts.verbose = opts.verbose === undefined ? false : opts.verbose;
+      opts['base-path'] = (opts['base-path'] ? opts['base-path'] : '/');
 
       opts['env-var'] = opts['env-var'] === undefined ? [] : opts['env-var'];
       opts['config-var'] = opts['config-var'] === undefined ? [] : opts['config-var'];

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -157,7 +157,7 @@ module.exports.run = function(opts, cb) {
       opts['node-version'] = opts['node-version'] === undefined ? DefaultNodeVersion : opts['node-version'];
       opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'https://apigee-interlude-gcpprod.e2e.apigee.net/turbo' : opts.edgeserviceshost;
       opts.verbose = opts.verbose === undefined ? false : opts.verbose;
-      opts['base-path'] = (opts['base-path'] ? opts['base-path'] : '/');
+      opts['base-path'] = (opts['base-path'] ? opts['base-path'] : '/'+opts.api);
 
       opts['env-var'] = opts['env-var'] === undefined ? [] : opts['env-var'];
       opts['config-var'] = opts['config-var'] === undefined ? [] : opts['config-var'];

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -806,7 +806,6 @@ function handleUploadResult(err, req, fileName, itemDone) {
 function createTarget(opts, request, done) {
   var targetDoc;
   
-  // we need the XML for a HostedTarget (or whatever)...this is just a place holder that isn't a ScriptTarget
   targetDoc = mustache.render(
   '<TargetEndpoint name="default">' +
   '<PreFlow name="PreFlow"/>' +

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -25,9 +25,7 @@ var templates = require('./edgeServicesTemplates');
 
 var DeploymentDelay = 60;
 var ProxyBase = 'apiproxy';
-var TriremeRuntimeOption = 'trireme';
-var EdgeServicesRuntimeOption = 'edgeServices'
-var DefaultNodeVersion = '7'
+var DefaultNodeVersion = '6'; // LTS
 
 // By default, do not run NPM remotely
 var DefaultResolveModules = false;
@@ -81,10 +79,10 @@ var descriptor = defaults.defaultDescriptor({
     shortOption: 'P',
     toggle: true
   },
-  runtime: {
-    name: 'Runtime to deploy the Node.js app to',
-    shortOption: 'r',
-    required: false
+  'edge-services': {
+    name: 'Use Edge Services to deploy the Node.js app',
+    shortOption: 's',
+    toggle: true
   },
   'node-version': {
     name: 'Version of node to use in EdgeServices',
@@ -101,10 +99,6 @@ var descriptor = defaults.defaultDescriptor({
     shortOption: 'C',
     required: false,
     array: true
-  },
-  edgeserviceshost: { // for testing while we don't have proxy
-    name: 'hostname of EdgeServices to target',
-    required: false
   }
 });
 module.exports.descriptor = descriptor;
@@ -137,7 +131,7 @@ module.exports.run = function(opts, cb) {
       }
     }
   }
-  if (opts.runtime != EdgeServicesRuntimeOption) {
+  if (!opts['edge-services']) {
     descriptor.main.required = true;
   }
   
@@ -152,16 +146,16 @@ module.exports.run = function(opts, cb) {
     if (err) { return cb(err); }
 
     var deploySeries;
-    if (opts.runtime === EdgeServicesRuntimeOption) {
+    if (opts['edge-services']) {
       // set defaults
-      opts['node-version'] = opts['node-version'] === undefined ? DefaultNodeVersion : opts['node-version'];
-      opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'https://apigee-interlude-gcpprod.e2e.apigee.net/turbo' : opts.edgeserviceshost;
+      opts['node-version'] = opts['node-version'] || DefaultNodeVersion;
+      opts.edgeservicestarget = process.env['EDGE_SERVICES_TARGET'] || 'https://apigee-interlude-gcpprod.e2e.apigee.net/turbo';
       opts.verbose = opts.verbose === undefined ? false : opts.verbose;
-      opts['base-path'] = (opts['base-path'] ? opts['base-path'] : '/'+opts.api);
+      opts['base-path'] = opts['base-path'] || ('/'+opts.api);
 
-      opts['env-var'] = opts['env-var'] === undefined ? [] : opts['env-var'];
-      opts['config-var'] = opts['config-var'] === undefined ? [] : opts['config-var'];
-      opts['vars'] = parseEnvConfigVars(opts['env-var'], opts['config-var'])
+      opts['env-var'] = opts['env-var'] || [];
+      opts['config-var'] = opts['config-var'] || [];
+      opts['vars'] = parseEnvConfigVars(opts['env-var'], opts['config-var']);
 
       deploySeries = [
           function(done) {
@@ -191,7 +185,7 @@ module.exports.run = function(opts, cb) {
             }
           }
         ]
-    } else if (opts.runtime === undefined || opts.runtime === TriremeRuntimeOption) { // default to Trireme 
+    } else { // default to Trireme 
       // if preserve-policies, we do something entirely different...
       if (opts['preserve-policies'] && opts.deploymentVersion > 1) {
         return preservePoliciesRun(opts, cb);
@@ -217,8 +211,6 @@ module.exports.run = function(opts, cb) {
           deployProxy(opts, request, done);
         }
       ]
-    } else {
-      return cb(new Error(util.format('invalid deploynodeapp runtime choice: %s', opts.runtime)))
     }
 
     // Run each function in series, and collect an array of results.
@@ -228,7 +220,7 @@ module.exports.run = function(opts, cb) {
         if (err) { return cb(err); }
         if (opts.debug) { console.log('results: %j', results); }
 
-        if (opts.runtime === EdgeServicesRuntimeOption) {
+        if (opts['edge-services']) {
           console.log(util.format('Deployment results:\n  Org: %s\n  Environments: %s\n  Application: %s\n  App Revision: %s\n', 
             opts.organization, 
             opts.environments, 
@@ -418,7 +410,7 @@ function getDeploymentInfo(opts, request, done) {
     return;
   }
 
-  if (opts.runtime != EdgeServicesRuntimeOption) {
+  if (!opts['edge-services']) {
     if (!fs.existsSync(path.join(opts.directory, opts.main))) {
       // Main script might be an absolute path, so fix it up
       opts.main = path.relative(opts.directory, opts.main);
@@ -518,7 +510,7 @@ function proxyCreationDone(err, req, body, opts, done) {
 }
 
 function getToken(opts, cb) {
-  var ssoURL = opts.baseuri && opts.baseuri.indexOf('e2e') > -1 ? 'https://login.e2e.apigee.net/oauth/token' : 'https://login.apigee.com/oauth/token'
+  var ssoURL = process.env['SSO_LOGIN_URL'] || 'https://login.e2e.apigee.net/oauth/token';
   post(ssoURL, {
     form: {
       username: opts.username,
@@ -562,7 +554,7 @@ function uploadNodeSourceToEdgeServices(opts, request, done) {
     targz.compress(opts.directory, target, function(err) {
       if (err) { return done(err) }
 
-      var uri = util.format('%s/organizations/%s/apps?stream=%s', opts.edgeserviceshost, opts.organization, opts.verbose);
+      var uri = util.format('%s/organizations/%s/apps?stream=%s', opts.edgeservicestarget, opts.organization, opts.verbose);
       
       if (opts.debug) { console.log('importing the archived source code into EdgeServices'); }
       // import source code archive into EdgeServices, stream messages
@@ -607,7 +599,7 @@ function deployEdgeServicesApplication(opts, request, imported, cb) {
   console.log('Deploying application...')
   var environments = opts.environments.split(',');
   environments.forEach(function(env, ndx, arr) {
-    var uri = util.format('%s/environments/%s:%s/deployments', opts.edgeserviceshost, opts.organization, env);
+    var uri = util.format('%s/environments/%s:%s/deployments', opts.edgeservicestarget, opts.organization, env);
     var payload = {
       application: opts.api,
       revision: imported.revision.revision,

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -86,7 +86,6 @@ var descriptor = defaults.defaultDescriptor({
   },
   'node-version': {
     name: 'Version of node to use in EdgeServices',
-    shortOption: 'x',
     required: false
   },
   'env-var': {
@@ -556,7 +555,6 @@ function uploadNodeSourceToEdgeServices(opts, request, done) {
 function deployEdgeServicesApplication(opts, request, imported, cb) {
   var uri = util.format('http://%s/environments/%s:%s/deployments', opts.edgeserviceshost, opts.organization, opts.environments);
   var payload = {
-    name: opts.api,
     application: opts.api,
     revision: imported.revision.revision,
     envVars: opts['vars'] // combination of standard environment & configuration-referenced variables
@@ -574,7 +572,7 @@ function deployEdgeServicesApplication(opts, request, imported, cb) {
       return cb(new Error('bad request, there was a missing parameter'));
     } else if (res.statusCode === 409) {
       return cb(new Error('a deployment with these parametes already exists. cancelling'));
-    } else if (res.statusCode === 200) {
+    } else if (res.statusCode === 201) {
       return cb(undefined, {
         import: imported,
         deploy: JSON.parse(body)

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -81,13 +81,8 @@ var descriptor = defaults.defaultDescriptor({
   },
   runtime: {
     name: 'Runtime to deploy the Node.js app to',
-    shortOption: 'B',
+    shortOption: 'r',
     required: false
-  },
-  stream: {
-    name: 'Stream EdgeServices API calls',
-    shortOption: 's',
-    toggle: true
   },
   'node-version': {
     name: 'Version of node to use in EdgeServices',
@@ -96,11 +91,13 @@ var descriptor = defaults.defaultDescriptor({
   },
   'env-var': {
     name: 'Environment variables for EdgeServices',
+    shortOption: 'E',
     required: false,
     array: true
   },
   'config-var': {
     name: 'Configuration-referenced variables for EdgeServices',
+    shortOption: 'C',
     required: false,
     array: true
   },
@@ -153,10 +150,10 @@ module.exports.run = function(opts, cb) {
     var deploySeries;
     if (opts.runtime === EdgeServicesRuntimeOption) {
       // set defaults
-      opts.stream = opts.stream === undefined ? false : opts.stream;
       opts['node-version'] = opts['node-version'] === undefined ? DefaultNodeVersion : opts['node-version'];
       opts.edgeserviceshost = opts.edgeserviceshost === undefined ? 'localhost:3000' : opts.edgeserviceshost; // this will go away when we have a stable target
-      
+      opts.verbose = opts.verbose === undefined ? false : opts.verbose;
+
       opts['env-var'] = opts['env-var'] === undefined ? [] : opts['env-var'];
       opts['config-var'] = opts['config-var'] === undefined ? [] : opts['config-var'];
       opts['vars'] = parseEnvConfigVars(opts['env-var'], opts['config-var'])
@@ -502,9 +499,7 @@ function importDeployToEdgeServices(opts, request, done) {
     function(imported, cb) {
       deployEdgeServicesApplication(opts, request, imported, cb)
     }
-  ], function(err, results) {
-    done(err, results)
-  })
+  ], done)
 }
 
 function uploadNodeSourceToEdgeServices(opts, request, done) {
@@ -517,7 +512,7 @@ function uploadNodeSourceToEdgeServices(opts, request, done) {
     targz.compress(opts.directory, target, function(err) {
       if (err) { return done(err) }
 
-      var uri = util.format('http://%s/organizations/%s/apps?stream=%s', opts.edgeserviceshost, opts.organization, opts.stream);
+      var uri = util.format('http://%s/organizations/%s/apps?stream=%s', opts.edgeserviceshost, opts.organization, opts.verbose);
       
       if (opts.debug) { console.log('importing the archived source code into EdgeServices'); }
       // import source code archive into EdgeServices, stream messages
@@ -547,9 +542,9 @@ function uploadNodeSourceToEdgeServices(opts, request, done) {
           }
 
           if (msg.done) {
-            if (opts.debug || opts.verbose || opts.stream) { console.log(util.format('Application "%s" revision "%s" built for "%s"', opts.api, msg.revision.revision, opts.organization)) }
+            if (opts.debug || opts.verbose) { console.log(util.format('Application "%s" revision "%s" built for "%s"', opts.api, msg.revision.revision, opts.organization)) }
             return done(null, msg) // end with the last message passed to the results
-          } else if (opts.verbose || opts.debug || opts.stream) {
+          } else if (opts.verbose || opts.debug) {
             console.log(msg.message)
           }
         })
@@ -560,17 +555,18 @@ function uploadNodeSourceToEdgeServices(opts, request, done) {
 
 function deployEdgeServicesApplication(opts, request, imported, cb) {
   var uri = util.format('http://%s/environments/%s:%s/deployments', opts.edgeserviceshost, opts.organization, opts.environments);
-  
-  if (opts.debug) { console.log('deploying application'); }
+  var payload = {
+    name: opts.api,
+    application: opts.api,
+    revision: imported.revision.revision,
+    envVars: opts['vars'] // combination of standard environment & configuration-referenced variables
+  }
+
+  if (opts.debug) { console.log('deploying application with payload:', payload); }
   request({
     uri: uri,
     method: 'POST',
-    body: {
-      name: opts.api,
-      application: opts.api,
-      revision: imported.revision.revision,
-      envVars: opts['vars'] // combination of standard environment & configuration-referenced variables
-    }
+    body: payload
   }, function(err, res, body) {
     if (err) { return cb(err); }
 
@@ -622,7 +618,7 @@ function parseEnvConfigVars(envVarStrings, configVarStrings) {
       }
     })
   });
-console.log(util.inspect(parsed, false, null))
+
   return parsed
 }
 

--- a/lib/commands/deploynodeapp.js
+++ b/lib/commands/deploynodeapp.js
@@ -663,46 +663,50 @@ function parseEnvConfigVars(envVarStrings, configVarStrings) {
 }
 
 function uploadEdgeServicesBundle(opts, request, done) {
-  tmp.dir({unsafeCleanup: true}, function(err, tmpDirPath, cleanup) {
-    var proxyBundleBase = path.join(tmpDirPath, 'apiproxy');
-    fs.mkdirSync(proxyBundleBase);
-    
-    // write base proxy file
-    var rootDoc = mustache.render(templates.rootXmlTemplate, opts);
-    var rootEntryName = opts.api + '.xml';
-    fs.writeFileSync(path.join(proxyBundleBase, rootEntryName), rootDoc);
+  var environments = opts.environments.split(',');
+  environments.forEach(function(env, ndx, arr) {
+    opts.environments = env
+    tmp.dir({unsafeCleanup: true}, function(err, tmpDirPath, cleanup) {
+      var proxyBundleBase = path.join(tmpDirPath, 'apiproxy');
+      fs.mkdirSync(proxyBundleBase);
+      
+      // write base proxy file
+      var rootDoc = mustache.render(templates.rootXmlTemplate, opts);
+      var rootEntryName = opts.api + '.xml';
+      fs.writeFileSync(path.join(proxyBundleBase, rootEntryName), rootDoc);
 
-    // write target file
-    var targetsDirPath = path.join(proxyBundleBase, 'targets');
-    fs.mkdirSync(targetsDirPath);
-    var targetDoc = mustache.render(templates.defaultTargetTemplate, opts);
-    fs.writeFileSync(path.join(targetsDirPath, 'default.xml'), targetDoc);
+      // write target file
+      var targetsDirPath = path.join(proxyBundleBase, 'targets');
+      fs.mkdirSync(targetsDirPath);
+      var targetDoc = mustache.render(templates.defaultTargetTemplate, opts);
+      fs.writeFileSync(path.join(targetsDirPath, 'default.xml'), targetDoc);
 
-    // write resource file
-    var resourceDirPath = path.join(proxyBundleBase, 'resources');
-    fs.mkdirSync(resourceDirPath);
-    var jscDirPath = path.join(resourceDirPath, 'jsc')
-    fs.mkdirSync(jscDirPath);
-    fs.writeFileSync(path.join(jscDirPath, 'gen-turbo-req.js'), templates.genTurboReqjs)
+      // write resource file
+      var resourceDirPath = path.join(proxyBundleBase, 'resources');
+      fs.mkdirSync(resourceDirPath);
+      var jscDirPath = path.join(resourceDirPath, 'jsc')
+      fs.mkdirSync(jscDirPath);
+      fs.writeFileSync(path.join(jscDirPath, 'gen-turbo-req.js'), templates.genTurboReqjs)
 
-    // write proxies file
-    var proxiesDirPath = path.join(proxyBundleBase, 'proxies');
-    fs.mkdirSync(proxiesDirPath);
-    var proxyDoc = mustache.render(templates.defaultProxyTemplate, opts);
-    fs.writeFileSync(path.join(proxiesDirPath, 'default.xml'), proxyDoc);
+      // write proxies file
+      var proxiesDirPath = path.join(proxyBundleBase, 'proxies');
+      fs.mkdirSync(proxiesDirPath);
+      var proxyDoc = mustache.render(templates.defaultProxyTemplate, opts);
+      fs.writeFileSync(path.join(proxiesDirPath, 'default.xml'), proxyDoc);
 
-    // write policy files
-    var policiesDirPath = path.join(proxyBundleBase, 'policies');
-    fs.mkdirSync(policiesDirPath);
-    fs.writeFileSync(path.join(policiesDirPath, 'GetTurboConfig.xml'), templates.getTurboConfig)
-    fs.writeFileSync(path.join(policiesDirPath, 'GenerateTurboRequest.xml'), templates.genTurboReqPolicy)
+      // write policy files
+      var policiesDirPath = path.join(proxyBundleBase, 'policies');
+      fs.mkdirSync(policiesDirPath);
+      fs.writeFileSync(path.join(policiesDirPath, 'GetTurboConfig.xml'), templates.getTurboConfig)
+      fs.writeFileSync(path.join(policiesDirPath, 'GenerateTurboRequest.xml'), templates.genTurboReqPolicy)
 
-    opts.directory = tmpDirPath
-    deployproxy.run(opts, function(err, dep) {
-      cleanup();
-      done(err, dep)
+      opts.directory = tmpDirPath
+      deployproxy.run(opts, function(err, dep) {
+        cleanup();
+        done(err, dep)
+      });
     });
-  });
+  }); 
 }
 
 function uploadNodeSource(opts, request, done) {

--- a/lib/commands/edgeServicesTemplates.js
+++ b/lib/commands/edgeServicesTemplates.js
@@ -40,7 +40,7 @@ module.exports.defaultTargetTemplate = '<?xml version="1.0" encoding="UTF-8" sta
     <HTTPTargetConnection> \
         <Properties/> \
         <!-- Dummy endpoint that will be replaced by the GenerateTurboRequest policy --> \
-        <URL>https://{{api}}-dot-{{environments}}.appspot.com/</URL> \
+        <URL>https://{{api}}-dot-{{organization}}.appspot.com/</URL> \
     </HTTPTargetConnection> \
 </TargetEndpoint>'
 

--- a/lib/commands/edgeServicesTemplates.js
+++ b/lib/commands/edgeServicesTemplates.js
@@ -1,0 +1,170 @@
+'use strict';
+
+module.exports.rootXmlTemplate = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?> \
+<APIProxy revision="1" name="{{api}}"> \
+    <ConfigurationVersion majorVersion="4" minorVersion="0"/> \
+    <DisplayName>{{api}}</DisplayName> \
+    <Policies> \
+        <Policy>GetTurboConfig</Policy> \
+        <Policy>GenerateTurboRequest</Policy> \
+    </Policies> \
+    <ProxyEndpoints> \
+        <ProxyEndpoint>default</ProxyEndpoint> \
+    </ProxyEndpoints> \
+    <Resources> \
+        <Resource>jsc://gen-target-url.js</Resource> \
+    </Resources> \
+    <TargetServers/> \
+    <TargetEndpoints> \
+        <TargetEndpoint>default</TargetEndpoint> \
+    </TargetEndpoints> \
+</APIProxy>'
+
+module.exports.defaultTargetTemplate = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?> \
+<TargetEndpoint name="default"> \
+    <Description/> \
+    <FaultRules/> \
+    <PreFlow name="PreFlow"> \
+        <Request> \
+            <Step> \
+                <Name>GenerateTurboRequest</Name> \
+            </Step> \
+        </Request> \
+        <Response/> \
+    </PreFlow> \
+    <PostFlow name="PostFlow"> \
+        <Request/> \
+        <Response/> \
+    </PostFlow> \
+    <Flows/> \
+    <HTTPTargetConnection> \
+        <Properties/> \
+        <!-- Dummy endpoint that will be replaced by the GenerateTurboRequest policy --> \
+        <URL>https://{{api}}-dot-{{environments}}.appspot.com/</URL> \
+    </HTTPTargetConnection> \
+</TargetEndpoint>'
+
+module.exports.genTurboReqjs = `// Fallback region for Turbo
+var defaultRegion = 'us-central';
+// Get MP region and map to a turbo gae region
+var edgeRegion = context.getVariable('system.region.name');
+var turboRegion = mapRegion(edgeRegion);
+
+// Locate region mapping in KVM, fallback to default region
+var projectId = context.getVariable('turbo-region-' + turboRegion) || context.getVariable('turbo-region-' + defaultRegion);
+if (projectId === '') {
+    throw new Error("Turbo project id was not found in KVM")
+}
+
+// Use proxy name as the deployment name
+var appName = context.getVariable('apiproxy.name');
+
+// Generate a target url using the appName and projectId and request path?query
+var targetUrl = 'https://' + appName + '-dot-' + projectId + '.appspot.com';
+targetUrl += context.getVariable('request.path');
+if (context.getVariable('request.querystring') !== "") {
+    targetUrl += '?' + context.getVariable('request.querystring');
+}
+
+// Set the new target url
+context.setVariable('target.url', targetUrl);
+// Set the routing key from the KVM
+context.setVariable("request.header.x-routing-api-key", context.getVariable('turbo-routing-key'));
+
+// Map a EC2/GCE region into a turbo GAE region
+function mapRegion(region) {
+    if (region === 'us-east1' ||
+        region === 'us-east-1' ||
+        region === 'us-east-2') {
+        return 'us-east1';
+    } else if (region === 'us-central' ||
+               region === 'us-west-1' ||
+               region === 'us-west-2' ||
+               region === 'ca-central-1') {
+        return 'us-central';
+    } else if (region === 'asia-northeast1' ||
+               region === 'ap-south-1' ||
+               region === 'ap-northeast-2' ||
+               region === 'ap-southeast-1' ||
+               region === 'ap-southeast-2' ||
+               region === 'ap-northeast-1' ||
+               region === 'asia-east1' ||
+               region === 'asia-northeast1' ) {
+        return 'asia-northeast1';
+    } else if (region === 'europe-west' ||
+               region === 'eu-central-1' ||
+               region === 'eu-west-1' ||
+               region === 'eu-west-2' ||
+               region === 'europe-west1') {
+        return 'europe-west';
+    } else {
+        return 'us-central';
+    }
+}`
+
+module.exports.defaultProxyTemplate = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ProxyEndpoint name="default">
+    <Description/>
+    <FaultRules/>
+    <PreFlow name="PreFlow">
+        <Request/>
+        <Response/>
+    </PreFlow>
+    <PostFlow name="PostFlow">
+        <Request>
+            <Step>
+                <Name>GetTurboConfig</Name>
+            </Step>
+        </Request>
+        <Response/>
+    </PostFlow>
+    <Flows/>
+    <HTTPProxyConnection>
+        <BasePath>/{{basepath}}</BasePath>
+        <Properties/>
+        <VirtualHost>default</VirtualHost>
+        <VirtualHost>secure</VirtualHost>
+    </HTTPProxyConnection>
+    <RouteRule name="default">
+        <TargetEndpoint>default</TargetEndpoint>
+    </RouteRule>
+</ProxyEndpoint>`
+
+module.exports.getTurboConfig = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<KeyValueMapOperations mapIdentifier="turbo-config" async="false" continueOnError="false" enabled="true" name="GetTurboConfig">
+    <DisplayName>GetTurboConfig</DisplayName>
+    <Scope>environment</Scope>
+    <Get assignTo="turbo-routing-key" index="1">
+        <Key>
+            <Parameter>routing:key</Parameter>
+        </Key>
+    </Get>
+    <Get assignTo="turbo-region-us-central" index="1">
+        <Key>
+            <Parameter>project:id:us-central</Parameter>
+        </Key>
+    </Get>
+    <Get assignTo="turbo-region-us-east1" index="1">
+        <Key>
+            <Parameter>project:id:us-east1</Parameter>
+        </Key>
+    </Get>
+    <Get assignTo="turbo-region-europe-west" index="1">
+        <Key>
+            <Parameter>project:id:europe-west</Parameter>
+        </Key>
+    </Get>
+    <Get assignTo="turbo-region-asia-northeast1" index="1">
+        <Key>
+            <Parameter>project:id:asia-northeast1</Parameter>
+        </Key>
+    </Get>
+</KeyValueMapOperations>`
+
+module.exports.genTurboReqPolicy = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript async="false" continueOnError="false" enabled="true" timeLimit="200" name="GenerateTurboRequest">
+    <DisplayName>GenerateTurboRequest</DisplayName>
+    <Properties/>
+    <ResourceURL>jsc://gen-turbo-req.js</ResourceURL>
+</Javascript>
+`

--- a/lib/commands/edgeServicesTemplates.js
+++ b/lib/commands/edgeServicesTemplates.js
@@ -120,7 +120,7 @@ module.exports.defaultProxyTemplate = `<?xml version="1.0" encoding="UTF-8" stan
     </PostFlow>
     <Flows/>
     <HTTPProxyConnection>
-        <BasePath>/{{basepath}}</BasePath>
+        <BasePath>/{{base-path}}</BasePath>
         <Properties/>
         <VirtualHost>default</VirtualHost>
         <VirtualHost>secure</VirtualHost>

--- a/lib/options.js
+++ b/lib/options.js
@@ -34,6 +34,20 @@ module.exports.getopts = function(argv, start, descriptor) {
           opts[longArgName] = true;
         } else if (i < (argv.length - 1)) {
           i++;
+          if (ld.array) {
+            if (!opts[longArgName]) {
+              opts[longArgName] = []
+            }
+
+            var val = argv[i]
+            if (ld.type === 'int') {
+              val = parseInt(val, 10);
+            }
+
+            opts[longArgName].push(val)
+            continue
+          }
+
           opts[longArgName] = argv[i];
 
           if (ld.type === 'int') {
@@ -69,6 +83,20 @@ module.exports.getopts = function(argv, start, descriptor) {
             opts[longName] = true;
           } else if (i < (argv.length - 1)) {
             i++;
+            if (des.array) {
+              if (!opts[longName]) {
+                opts[longName] = []
+              }
+
+              var val = argv[i]
+              if (des.type === 'int') {
+                val = parseInt(val, 10);
+              }
+
+              opts[longName].push(val)
+              continue
+            }
+
             opts[longName] = argv[i];
 
             if (des.type === 'int') {

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
     "body-parser": "^1.14.0",
     "cli-table": "^0.3.0",
     "mustache": "^2.1.3",
+    "netrc": "^0.1.3",
     "node-unzip-2": "^0.2.1",
     "node-zip": "^1.1.1",
+    "q": "*",
     "read": "^1.0.7",
     "request": "^2.63.0",
+    "tar.gz": "^1.0.5",
     "tmp": "^0.0.27",
-    "underscore": "^1.8.3",
-    "netrc" : "^0.1.3",
-    "q": "*"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "connect": "^3.4.0",


### PR DESCRIPTION
This is the first pass at EdgeServices integration, many things are still in flux. I would like basic/functional code review. Integration testing is impossible currently due to outstanding permissions issues in Turbo.

To consider during review:
* we don't have a default target for EdgeServices yet, thus I have a flag `--edgeserviceshost` so that i can toggle between running the server locally and the one in GKE. This will be removed.
* this integration only works when a token is passed via --token...the other built-in option is basic auth, which Turbo doesn't support, so we need to generate a token when those options are used.
* the `--preserve-policies` option maintains the proxy policies, and changes the node source in Trireme...should we just import a new application revision and update the deployment when using EdgeServices? Currently not supporting this
* how chatty should this command be when building an image, deploying an app, etc.? default is silence, but I don't like that it just hangs for 1-2 minutes...thoughts?